### PR TITLE
Remove ArgumentNullException and redirect to Home

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 
 namespace DevAdventCalendarCompetition.Controllers
@@ -18,13 +19,16 @@ namespace DevAdventCalendarCompetition.Controllers
     {
         private readonly IAccountService accountService;
         private readonly ILogger logger;
+        private readonly LinkGenerator linkGenerator;
 
         public AccountController(
             IAccountService accountService,
-            ILogger<AccountController> logger)
+            ILogger<AccountController> logger,
+            LinkGenerator linkGenerator)
         {
             this.accountService = accountService ?? throw new ArgumentNullException(nameof(accountService));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.linkGenerator = linkGenerator ?? throw new ArgumentNullException(nameof(linkGenerator));
         }
 
         [TempData]
@@ -34,17 +38,12 @@ namespace DevAdventCalendarCompetition.Controllers
         [AllowAnonymous]
         public async Task<IActionResult> Login(Uri returnUrl = null)
         {
-            if (returnUrl is null)
-            {
-                throw new ArgumentNullException(nameof(returnUrl));
-            }
-
             // Clear the existing external cookie to ensure a clean login process
             await this.HttpContext.SignOutAsync(IdentityConstants.ExternalScheme).ConfigureAwait(false);
 
             var model = new LoginViewModel();
 
-            this.ViewData["ReturnUrl"] = returnUrl;
+            this.ViewData["ReturnUrl"] = returnUrl ?? new Uri(this.linkGenerator.GetUriByAction(this.HttpContext, nameof(HomeController.Index), "Home"));
             return this.View(model);
         }
 
@@ -349,7 +348,6 @@ namespace DevAdventCalendarCompetition.Controllers
 #pragma warning disable CA1303 // Do not pass literals as localized parameters
                 throw new ArgumentException("Kod musi być dostarczony do resetowania hasła.");
 #pragma warning restore CA1303 // Do not pass literals as localized parameters
-
             }
 
             var model = new ResetPasswordViewModel { Code = code, Email = email };

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
@@ -6,6 +6,7 @@ using DevAdventCalendarCompetition.Models.AccountViewModels;
 using DevAdventCalendarCompetition.Services.Interfaces;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
@@ -19,16 +20,13 @@ namespace DevAdventCalendarCompetition.Controllers
     {
         private readonly IAccountService accountService;
         private readonly ILogger logger;
-        private readonly LinkGenerator linkGenerator;
 
         public AccountController(
             IAccountService accountService,
-            ILogger<AccountController> logger,
-            LinkGenerator linkGenerator)
+            ILogger<AccountController> logger)
         {
             this.accountService = accountService ?? throw new ArgumentNullException(nameof(accountService));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            this.linkGenerator = linkGenerator ?? throw new ArgumentNullException(nameof(linkGenerator));
         }
 
         [TempData]
@@ -43,7 +41,7 @@ namespace DevAdventCalendarCompetition.Controllers
 
             var model = new LoginViewModel();
 
-            this.ViewData["ReturnUrl"] = returnUrl ?? new Uri(this.linkGenerator.GetUriByAction(this.HttpContext, nameof(HomeController.Index), "Home"));
+            this.ViewData["ReturnUrl"] = returnUrl ?? this.HomeUri();
             return this.View(model);
         }
 
@@ -423,6 +421,15 @@ namespace DevAdventCalendarCompetition.Controllers
             {
                 return this.RedirectToAction(nameof(HomeController.Index), "Home");
             }
+        }
+
+        private Uri HomeUri()
+        {
+            var homePath = this.Url.Action(nameof(HomeController.Index), "Home");
+            var scheme = this.HttpContext.Request.Scheme;
+            var defaultPort = scheme == "https" ? 443 : 80;
+            var builder = new UriBuilder(scheme: this.HttpContext.Request.Scheme, host: this.HttpContext.Request.Host.Host, port: this.HttpContext.Request.Host.Port ?? defaultPort, pathValue: homePath);
+            return builder.Uri;
         }
     }
 }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using DevAdventCalendarCompetition.Extensions;
@@ -426,9 +427,13 @@ namespace DevAdventCalendarCompetition.Controllers
         private Uri HomeUri()
         {
             var homePath = this.Url.Action(nameof(HomeController.Index), "Home");
-            var scheme = this.HttpContext.Request.Scheme;
-            var defaultPort = scheme == "https" ? 443 : 80;
-            var builder = new UriBuilder(scheme: this.HttpContext.Request.Scheme, host: this.HttpContext.Request.Host.Host, port: this.HttpContext.Request.Host.Port ?? defaultPort, pathValue: homePath);
+            var fullUrlString = string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}://{1}{2}",
+                this.HttpContext.Request.Scheme,
+                this.HttpContext.Request.Host, homePath);
+            var uri = new Uri(fullUrlString);
+            var builder = new UriBuilder(uri);
             return builder.Uri;
         }
     }


### PR DESCRIPTION
## Description
Injected a LinkGenerator From ASP.Net core into the Account Controller and stored it.
Removed the null check on returnUri in the AccountController#Login method. 
Used the Null Coalescing operator to return to the home page if returnUri is null. 

## Where should the reviewer start?
Run project and navigate to `/Account/Login`. Page should load without errors thrown. Review the code within the `AccountController.cs` file, specifically in the constructor and the `Login` method

## Motivation and context
resolves a null argument exception when navigating directly to `/Account/Login/` while in local development. If returnUri is null, this will redirect to the home index action.
Fix for issue #163

## How has this been tested?
I have not tested this, but would like to make sure it is tested. I do not have a copy of the DB and this project doesn't have the necessary packages for me to do it 
```
dotnet ef database update --project src\DevAdventCalendarCompetition\DevAdventCalendarCompetition.Repository\DevAdventCalendarCompetition.Repository.csproj --startup-project src\DevAdventCalendarCompetition\DevAdventCalendarCompetition\DevAdventCalendarCompetition.csproj
Your startup project 'DevAdventCalendarCompetition' doesn't reference Microsoft.EntityFrameworkCore.Design. This package is required for the Entity Framework Core Tools to work. Ensure your startup project is correct, install the package, and try again.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
