### PR TITLE
Added forwarded headers options to startup

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/EmailSender.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/EmailSender.cs
@@ -18,7 +18,7 @@ namespace DevAdventCalendarCompetition.Services
 
         public string Password { get; set; }
 
-        public Task SendEmailAsync(string email, string subject, string message)
+        public async Task SendEmailAsync(string email, string subject, string message)
         {
             using (var smtpClient = new SmtpClient
             {
@@ -28,14 +28,14 @@ namespace DevAdventCalendarCompetition.Services
                 Credentials = new NetworkCredential(this.UserName, this.Password)
             })
 
-            using (var mailMessage = new MailMessage("devadventcalendar@gmail.com", email)
+            using (var mailMessage = new MailMessage(this.UserName, email)
             {
                 Subject = subject,
                 IsBodyHtml = true,
                 Body = message
             })
             {
-                return smtpClient.SendMailAsync(mailMessage);
+                await smtpClient.SendMailAsync(mailMessage).ConfigureAwait(false);
             }
         }
     }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Extensions/EmailSenderExtensions.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Extensions/EmailSenderExtensions.cs
@@ -1,19 +1,20 @@
-﻿using System.Text.Encodings.Web;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using DevAdventCalendarCompetition.Services.Interfaces;
 
 namespace DevAdventCalendarCompetition.Services.Extensions
 {
     public static class EmailSenderExtensions
     {
-        public static Task SendEmailConfirmationAsync(this IEmailSender emailSender, string email, string link)
+        public static async Task SendEmailConfirmationAsync(this IEmailSender emailSender, string email, string link)
         {
             if (emailSender is null)
             {
                 throw new System.ArgumentNullException(nameof(emailSender));
             }
 
-            return emailSender.SendEmailAsync(email, "Potwierdzenie założenia konta", $"{$"Prosimy o potwierdzenie założenia konta poprzez kliknięcie na link <p><a href='{link}'>LINK</a></p>"}{$"<p>Jeżeli autentykacja została przeprowadzona przy pomocy zewnętrznego dostawcy (Facebook, Twitter, Google, GitHub), "}{$"żeby się zalogować do kalendarza, po przejściu na ekran logowania należy kliknąć w przycisk odpowiadający danemu dostawcy.</p>"}{$"<p>Pozdrawiamy,<br />Elfy DevAdventCalendar</p>"}{$"<p>PS. Dodatkowo będzie nam bardzo miło, jeśli dasz łapkę w górę na <a href='https://www.facebook.com/devadventcalendar/'>Facebooku</a> "}{$"i <a href='https://twitter.com/dev_advent_cal'>Twitterze</a>!</p>"}");
+            await emailSender
+                .SendEmailAsync(email, "Potwierdzenie założenia konta", $"{$"Prosimy o potwierdzenie założenia konta poprzez kliknięcie na link <p><a href='{link}'>LINK</a></p>"}{$"<p>Jeżeli autentykacja została przeprowadzona przy pomocy zewnętrznego dostawcy (Facebook, Twitter, Google, GitHub), "}{$"żeby się zalogować do kalendarza, po przejściu na ekran logowania należy kliknąć w przycisk odpowiadający danemu dostawcy.</p>"}{$"<p>Pozdrawiamy,<br />Elfy DevAdventCalendar</p>"}{$"<p>PS. Dodatkowo będzie nam bardzo miło, jeśli dasz łapkę w górę na <a href='https://www.facebook.com/devadventcalendar/'>Facebooku</a> "}{$"i <a href='https://twitter.com/dev_advent_cal'>Twitterze</a>!</p>"}")
+                .ConfigureAwait(false);
         }
     }
 }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Startup.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Startup.cs
@@ -40,6 +40,7 @@ namespace DevAdventCalendarCompetition
         public static void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UpdateDatabase();
+            app.UseForwardedHeaders();
 
             if (env.IsDevelopment())
             {
@@ -116,6 +117,12 @@ namespace DevAdventCalendarCompetition
 
                 options.DefaultRequestCulture = new RequestCulture("pl-PL");
                 options.SupportedCultures = supportedCultures;
+            });
+
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders =
+                    ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
             });
         }
     }


### PR DESCRIPTION
Authentication with external providers stopped working some time ago. 
TL/DR: Forwarded Headers Middleware must be enabled when application is behind reverse proxy.

## Description
DevAdventCalendar is hosted behind traefik. It means, that requests are coming into app from another container, not directly. It seems that ASP.NET Core 2.2 is checking origin when it comes to OAuth authentication. So to get it work the right way, we need to forward origin url and protocol of the request. This can be done easily with middleware. For details, please check this [link](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/?view=aspnetcore-2.2&tabs=visual-studio#forward-request-information-with-a-proxy-or-load-balancer).

## Where should the reviewer start?
This is very specific kind of change which can be tested only on uat or production env (because OAuth providers have configured redirect urls and only those are valid).

## Motivation and context
The problem with login showed up in 2019 version. It must have been some nuget update, because it still works in 2018 version.

## How has this been tested?
On dev/uat environment with facebook provider.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
