### PR TITLE
Changed arguments being passed to user verification method

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
@@ -135,9 +135,9 @@ namespace DevAdventCalendarCompetition.Controllers
                 {
                     this._logger.LogInformation(LoggingMessages.NewAccount);
 
-                    // var code = await this._accountService.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
-                    // var callbackUrl = this.Url.EmailConfirmationLink(user.Id, code, this.Request.Scheme);
-                    // await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl)).ConfigureAwait(false);
+                    var code = await this._accountService.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
+                    var callbackUrl = this.Url.EmailConfirmationLink(user.Id, code, this.Request.Scheme);
+                    await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl)).ConfigureAwait(false);
                     return this.View("RegisterConfirmation");
                 }
 

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
@@ -76,7 +76,7 @@ namespace DevAdventCalendarCompetition.Controllers
 
                 // This doesn't count login failures towards account lockout
                 // To enable password failures to trigger account lockout, set lockoutOnFailure: true
-                var result = await this._accountService.PasswordSignInAsync(model.Email, model.Password, model.RememberMe).ConfigureAwait(false);
+                var result = await this._accountService.PasswordSignInAsync(user.UserName, model.Password, model.RememberMe).ConfigureAwait(false);
 
                 if (result.Succeeded)
                 {
@@ -135,10 +135,9 @@ namespace DevAdventCalendarCompetition.Controllers
                 {
                     this._logger.LogInformation(LoggingMessages.NewAccount);
 
-                    var code = await this._accountService.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
-                    var callbackUrl = this.Url.EmailConfirmationLink(user.Id, code, this.Request.Scheme);
-                    await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl)).ConfigureAwait(false);
-
+                    // var code = await this._accountService.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
+                    // var callbackUrl = this.Url.EmailConfirmationLink(user.Id, code, this.Request.Scheme);
+                    // await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl)).ConfigureAwait(false);
                     return this.View("RegisterConfirmation");
                 }
 


### PR DESCRIPTION
PasswordSignInAsync requires actual user name value, not his email. So, I swapped the arguments. 

## Motivation and context
#243 

## How has this been tested?
1. Run app.
2. Create new user (email should be confirmed).
3. Log in.
4. Change email (new email should be confirmed again).
5. Try to log in with new email.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
