### PR TITLE
Hotfix/result message

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Home/Results.cshtml
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Home/Results.cshtml
@@ -37,7 +37,7 @@ else
         <div class="container">
             <div class="col-md-12">
                 <div class="party_text">
-                    @if (Model.CurrentUserPosition != 0)
+                    @*@if (Model.CurrentUserPosition != 0)
                     {
                         <h1 class="mb-30">
                             Zajmujesz <span>@Model.CurrentUserPosition</span> miejsce!
@@ -48,7 +48,7 @@ else
                         <h1 class="mb-30">
                             Niestety, nie odpowiedziałeś na żadną zagadkę ;(
                         </h1>
-                    }
+                    }*@
                     <img src="~/theme-2019/images/gift_bag.png" alt="gifts">
                 </div>
             </div>

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Home/Results.cshtml
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Home/Results.cshtml
@@ -1,4 +1,4 @@
-﻿<div class="breadcrumb_area">
+<div class="breadcrumb_area">
     <div class="container">
         <div class="row">
             <div class="breadcrumb_wrapper">
@@ -37,18 +37,23 @@ else
         <div class="container">
             <div class="col-md-12">
                 <div class="party_text">
-                    @*@if (Model.CurrentUserPosition != 0)
+                    @if (Model.CurrentUserPosition != 0)
                     {
                         <h1 class="mb-30">
                             Zajmujesz <span>@Model.CurrentUserPosition</span> miejsce!
                         </h1>
+                        <p>
+                            Punkty są zliczane raz w tygodniu. Twoja pozycja odnosi się do ostatniego zamkniętego tygodnia
+                            lub do całości konkursu, jeśli ten został już zakończony.
+                        </p>
                     }
                     else
                     {
-                        <h1 class="mb-30">
-                            Niestety, nie odpowiedziałeś na żadną zagadkę ;(
-                        </h1>
-                    }*@
+                        <h1 class="mb-30">Wyniki już niedługo...</h1>
+                        <p>
+                            Twoja pozycja będzie dostępna po zliczeniu wyników z pierwszego tygodnia konkursu.
+                        </p>
+                    }
                     <img src="~/theme-2019/images/gift_bag.png" alt="gifts">
                 </div>
             </div>


### PR DESCRIPTION
Removed confusing message about competition results

## Description
Last year we calculated results just-in-time. This year we have changed this, so results will be calculated per week and final results will be available when the competition is done. The problem is, that during first week everyone have 0 points and it's causing the confusing message to appear at results screen. This PR changes the message to be more clear.

## Where should the reviewer start?
Check the results screen, add some points to your user and check it again

## Motivation and context
#260 

## How has this been tested?
On local env

## Screenshots (if appropriate)
Message during first week:
![image](https://user-images.githubusercontent.com/9091483/69919573-a252ed80-147e-11ea-9ca1-578789345508.png)
Message after first week:
![image](https://user-images.githubusercontent.com/9091483/69919588-d5957c80-147e-11ea-8953-fb1b33480930.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
