### PR TITLE
Hotfix/results view performance

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/HomeRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/HomeRepository.cs
@@ -80,6 +80,28 @@ namespace DevAdventCalendarCompetition.Repository
                 .Count();
         }
 
+        public IDictionary<string, int> GetCorrectAnswersPerUserForDateRange(DateTimeOffset dateFrom, DateTimeOffset dateTo)
+        {
+            return this._dbContext
+                .TestAnswer
+                .Where(a => a.AnsweringTime.CompareTo(dateFrom.DateTime) >= 0 &&
+                            a.AnsweringTime.CompareTo(dateTo.DateTime) < 0)
+                .GroupBy(a => a.UserId)
+                .Select(ug => new KeyValuePair<string, int>(ug.Key, ug.Count()))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
+        public IDictionary<string, int> GetWrongAnswersPerUserForDateRange(DateTimeOffset dateFrom, DateTimeOffset dateTo)
+        {
+            return this._dbContext
+                .TestWrongAnswer
+                .Where(a => a.Time.CompareTo(dateFrom.DateTime) >= 0 &&
+                            a.Time.CompareTo(dateTo.DateTime) < 0)
+                .GroupBy(a => a.UserId)
+                .Select(ug => new KeyValuePair<string, int>(ug.Key, ug.Count()))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
         public List<Result> GetAllTestResults()
         {
             return this._dbContext.Set<Result>()

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/HomeRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/HomeRepository.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using DevAdventCalendarCompetition.Repository.Context;
 using DevAdventCalendarCompetition.Repository.Interfaces;
 using DevAdventCalendarCompetition.Repository.Models;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 
 namespace DevAdventCalendarCompetition.Repository
 {
@@ -58,28 +55,6 @@ namespace DevAdventCalendarCompetition.Repository
                 .Count();
         }
 
-        public int GetCorrectAnswersCountForUserAndDateRange(string userId, DateTimeOffset dateFrom, DateTimeOffset dateTo)
-        {
-            return this._dbContext
-                .TestAnswer
-                .Where(a => a.UserId == userId &&
-                            a.AnsweringTime.CompareTo(dateFrom.DateTime) >= 0 &&
-                            a.AnsweringTime.CompareTo(dateTo.DateTime) < 0)
-                .GroupBy(t => t.TestId)
-                .Count();
-        }
-
-        public int GetWrongAnswersCountForUserAndDateRange(string userId, DateTimeOffset dateFrom, DateTimeOffset dateTo)
-        {
-            return this._dbContext
-                .TestWrongAnswer
-                .Where(a => a.UserId == userId &&
-                            a.Time.CompareTo(dateFrom.DateTime) >= 0 &&
-                            a.Time.CompareTo(dateTo.DateTime) < 0)
-                .GroupBy(t => t.TestId)
-                .Count();
-        }
-
         public IDictionary<string, int> GetCorrectAnswersPerUserForDateRange(DateTimeOffset dateFrom, DateTimeOffset dateTo)
         {
             return this._dbContext
@@ -100,14 +75,6 @@ namespace DevAdventCalendarCompetition.Repository
                 .GroupBy(a => a.UserId)
                 .Select(ug => new KeyValuePair<string, int>(ug.Key, ug.Count()))
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-        }
-
-        public List<Result> GetAllTestResults()
-        {
-            return this._dbContext.Set<Result>()
-                .Include(u => u.User)
-                .OrderBy(r => r.Id)
-                .ToList();
         }
 
         public int GetUserPosition(string userId)

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/Interfaces/IHomeRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/Interfaces/IHomeRepository.cs
@@ -22,6 +22,10 @@ namespace DevAdventCalendarCompetition.Repository.Interfaces
 
         int GetWrongAnswersCountForUserAndDateRange(string userId, DateTimeOffset dateFrom, DateTimeOffset dateTo);
 
+        IDictionary<string, int> GetCorrectAnswersPerUserForDateRange(DateTimeOffset dateFrom, DateTimeOffset dateTo);
+
+        IDictionary<string, int> GetWrongAnswersPerUserForDateRange(DateTimeOffset dateFrom, DateTimeOffset dateTo);
+
         List<Result> GetAllTestResults();
 
         int GetUserPosition(string userId);

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/Interfaces/IHomeRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/Interfaces/IHomeRepository.cs
@@ -18,15 +18,9 @@ namespace DevAdventCalendarCompetition.Repository.Interfaces
 
         int GetCorrectAnswersCountForUser(string userId);
 
-        int GetCorrectAnswersCountForUserAndDateRange(string userId, DateTimeOffset dateFrom, DateTimeOffset dateTo);
-
-        int GetWrongAnswersCountForUserAndDateRange(string userId, DateTimeOffset dateFrom, DateTimeOffset dateTo);
-
         IDictionary<string, int> GetCorrectAnswersPerUserForDateRange(DateTimeOffset dateFrom, DateTimeOffset dateTo);
 
         IDictionary<string, int> GetWrongAnswersPerUserForDateRange(DateTimeOffset dateFrom, DateTimeOffset dateTo);
-
-        List<Result> GetAllTestResults();
 
         int GetUserPosition(string userId);
 

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/HomeService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/HomeService.cs
@@ -58,23 +58,23 @@ namespace DevAdventCalendarCompetition.Services
         public Dictionary<int, List<TestResultDto>> GetAllTestResults()
         {
             var testResultDictionary = new Dictionary<int, List<TestResultDto>>();
-            var week1results = this._homeRepository.GetTestResultsForWeek(1);
+            var week1Results = this._homeRepository.GetTestResultsForWeek(1);
 
-            if (week1results != null && week1results.Count > 0)
+            if (week1Results != null && week1Results.Count > 0)
             {
-                testResultDictionary.Add(1, this.FillResultsWithAnswersStats(1, this._mapper.Map<List<TestResultDto>>(week1results)));
+                testResultDictionary.Add(1, this.FillResultsWithAnswersStats(1, this._mapper.Map<List<TestResultDto>>(week1Results)));
 
-                var week2results = this._homeRepository.GetTestResultsForWeek(2);
+                var week2Results = this._homeRepository.GetTestResultsForWeek(2);
 
-                if (week2results != null && week2results.Count > 0)
+                if (week2Results != null && week2Results.Count > 0)
                 {
-                    testResultDictionary.Add(2, this.FillResultsWithAnswersStats(2, this._mapper.Map<List<TestResultDto>>(week2results)));
+                    testResultDictionary.Add(2, this.FillResultsWithAnswersStats(2, this._mapper.Map<List<TestResultDto>>(week2Results)));
 
-                    var week3results = this._homeRepository.GetTestResultsForWeek(3);
+                    var week3Results = this._homeRepository.GetTestResultsForWeek(3);
 
-                    if (week3results != null && week3results.Count > 0)
+                    if (week3Results != null && week3Results.Count > 0)
                     {
-                        testResultDictionary.Add(3, this.FillResultsWithAnswersStats(3, this._mapper.Map<List<TestResultDto>>(week3results)));
+                        testResultDictionary.Add(3, this.FillResultsWithAnswersStats(3, this._mapper.Map<List<TestResultDto>>(week3Results)));
 
                         var fullResults = this._homeRepository.GetTestResultsForWeek(4);
 

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/HomeService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/HomeService.cs
@@ -123,36 +123,38 @@ namespace DevAdventCalendarCompetition.Services
 
         private List<TestResultDto> FillResultsWithAnswersStats(int weekNumber, List<TestResultDto> results)
         {
+            DateTimeOffset dateFrom;
+            DateTimeOffset dateTo;
+
+            switch (weekNumber)
+            {
+                case 1:
+                    dateFrom = new DateTimeOffset(DateTime.Now.Year, 12, 1, 20, 0, 0, TimeSpan.Zero);
+                    dateTo = new DateTimeOffset(DateTime.Now.Year, 12, 8, 20, 0, 0, TimeSpan.Zero);
+                    break;
+                case 2:
+                    dateFrom = new DateTimeOffset(DateTime.Now.Year, 12, 8, 20, 0, 0, TimeSpan.Zero);
+                    dateTo = new DateTimeOffset(DateTime.Now.Year, 12, 15, 20, 0, 0, TimeSpan.Zero);
+                    break;
+                case 3:
+                    dateFrom = new DateTimeOffset(DateTime.Now.Year, 12, 15, 20, 0, 0, TimeSpan.Zero);
+                    dateTo = new DateTimeOffset(DateTime.Now.Year, 12, 22, 20, 0, 0, TimeSpan.Zero);
+                    break;
+                default:
+                    dateFrom = new DateTimeOffset(DateTime.Now.Year, 12, 1, 20, 0, 0, TimeSpan.Zero);
+                    dateTo = new DateTimeOffset(DateTime.Now.Year, 12, 25, 20, 0, 0, TimeSpan.Zero);
+                    break;
+            }
+
+            var correctAnswers = this._homeRepository.GetCorrectAnswersPerUserForDateRange(dateFrom, dateTo);
+            var wrongAnswers = this._homeRepository.GetWrongAnswersPerUserForDateRange(dateFrom, dateTo);
+
             foreach (var result in results)
             {
-                DateTimeOffset dateFrom;
-                DateTimeOffset dateTo;
-
-                switch (weekNumber)
-                {
-                    case 1:
-                        dateFrom = new DateTimeOffset(DateTime.Now.Year, 12, 1, 20, 0, 0, TimeSpan.Zero);
-                        dateTo = new DateTimeOffset(DateTime.Now.Year, 12, 8, 20, 0, 0, TimeSpan.Zero);
-                        break;
-                    case 2:
-                        dateFrom = new DateTimeOffset(DateTime.Now.Year, 12, 8, 20, 0, 0, TimeSpan.Zero);
-                        dateTo = new DateTimeOffset(DateTime.Now.Year, 12, 15, 20, 0, 0, TimeSpan.Zero);
-                        break;
-                    case 3:
-                        dateFrom = new DateTimeOffset(DateTime.Now.Year, 12, 15, 20, 0, 0, TimeSpan.Zero);
-                        dateTo = new DateTimeOffset(DateTime.Now.Year, 12, 22, 20, 0, 0, TimeSpan.Zero);
-                        break;
-                    default:
-                        dateFrom = new DateTimeOffset(DateTime.Now.Year, 12, 1, 20, 0, 0, TimeSpan.Zero);
-                        dateTo = new DateTimeOffset(DateTime.Now.Year, 12, 25, 20, 0, 0, TimeSpan.Zero);
-                        break;
-                }
-
-                var correctAnswersCount = this._homeRepository.GetCorrectAnswersCountForUserAndDateRange(result.UserId, dateFrom, dateTo);
-                var wrongAnswersCount =
-                    this._homeRepository.GetWrongAnswersCountForUserAndDateRange(result.UserId, dateFrom, dateTo);
-
+                correctAnswers.TryGetValue(result.UserId, out var correctAnswersCount);
                 result.CorrectAnswersCount = correctAnswersCount;
+
+                wrongAnswers.TryGetValue(result.UserId, out var wrongAnswersCount);
                 result.WrongAnswersCount = wrongAnswersCount;
             }
 


### PR DESCRIPTION
Fixed the very slow results page loading.

## Description
The results were filled with correct and wrong answers count per each user. We have about 2k users, so this was causing 4k+ requests to database per one page reload. I've changed it to get answers for all users at once. The new methods return dictionary with user id as key and correct/wrong answers count as value. That's only 2 request per page reload. 

## Where should the reviewer start?
Check the new repository methods logic carefully if I haven't made any logical mistake. I'm calculating elements after grouping by users, because each user can answer only once to given test, so grouping by test id in specific user group and counting it would give the same result.

## Motivation and context
Very slow results page loading

## How has this been tested?
Manually, I've compared the result before and after change, they were the same.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
