### PR TITLE
Show users' position per week

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/HomeRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/HomeRepository.cs
@@ -77,37 +77,37 @@ namespace DevAdventCalendarCompetition.Repository
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
-        public int GetUserPosition(string userId)
+        public int[] GetUserPositions(string userId)
         {
             var result = this._dbContext.Results
                 .FirstOrDefault(x => x.UserId == userId);
 
-            if (result == null)
+            var userPositions = new int[4];
+
+            if (result != null)
             {
-                return 0;
+                if (result.FinalPlace > 0)
+                {
+                    userPositions[3] = result.FinalPlace.Value;
+                }
+
+                if (result.Week3Place > 0)
+                {
+                    userPositions[2] = result.Week3Place.Value;
+                }
+
+                if (result.Week2Place > 0)
+                {
+                    userPositions[1] = result.Week2Place.Value;
+                }
+
+                if (result.Week1Place > 0)
+                {
+                    userPositions[0] = result.Week1Place.Value;
+                }
             }
 
-            if (result.FinalPlace > 0)
-            {
-                return result.FinalPlace.Value;
-            }
-
-            if (result.Week3Place > 0)
-            {
-                return result.Week3Place.Value;
-            }
-
-            if (result.Week2Place > 0)
-            {
-                return result.Week2Place.Value;
-            }
-
-            if (result.Week1Place > 0)
-            {
-                return result.Week1Place.Value;
-            }
-
-            return 0;
+            return userPositions;
         }
 
         public List<Result> GetTestResultsForWeek(int weekNumber)

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/Interfaces/IHomeRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/Interfaces/IHomeRepository.cs
@@ -22,7 +22,7 @@ namespace DevAdventCalendarCompetition.Repository.Interfaces
 
         IDictionary<string, int> GetWrongAnswersPerUserForDateRange(DateTimeOffset dateFrom, DateTimeOffset dateTo);
 
-        int GetUserPosition(string userId);
+        int[] GetUserPositions(string userId);
 
         List<Result> GetTestResultsForWeek(int weekNumber);
     }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/HomeService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/HomeService.cs
@@ -101,9 +101,9 @@ namespace DevAdventCalendarCompetition.Services
             return this._homeRepository.GetCorrectAnswersCountForUser(userId);
         }
 
-        public int GetUserPosition(string userId)
+        public int[] GetUserPositions(string userId)
         {
-            return this._homeRepository.GetUserPosition(userId);
+            return this._homeRepository.GetUserPositions(userId);
         }
 
         public string PrepareUserEmailForRODO(string email)

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Interfaces/IHomeService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Interfaces/IHomeService.cs
@@ -19,7 +19,7 @@ namespace DevAdventCalendarCompetition.Services.Interfaces
 
         Dictionary<int, List<TestResultDto>> GetAllTestResults();
 
-        int GetUserPosition(string userId);
+        int[] GetUserPositions(string userId);
 
         string PrepareUserEmailForRODO(string email);
     }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultRepository.cs
@@ -61,7 +61,7 @@ namespace DevAdventCalendarCompetition.TestResultService
                         StartDate = t.StartDate.Value,
                         WrongAnswers = w.Where(answer => answer.UserId == userId)
                     })
-                .Where(a => a.StartDate >= dateFrom.DateTime && a.StartDate <= dateTo)
+                .Where(a => a.StartDate >= dateFrom.DateTime && a.StartDate < dateTo)
                 .Select(t => t.WrongAnswers.Count())
                 .ToArray();
         }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultRepository.cs
@@ -52,23 +52,14 @@ namespace DevAdventCalendarCompetition.TestResultService
         {
             return _dbContext
                 .Test
-                .GroupJoin(_dbContext.TestWrongAnswer, 
-                    t => t.Id, 
+                .GroupJoin(_dbContext.TestWrongAnswer,
+                    t => t.Id,
                     w => w.TestId,
                     (t, w) => new
                     {
                         TestId = t.Id,
                         StartDate = t.StartDate.Value,
                         WrongAnswers = w.Where(answer => answer.UserId == userId)
-                    })
-                .Join(_dbContext.TestAnswer.Where(answer => answer.UserId != userId), 
-                    t => t.TestId, 
-                    answer => answer.TestId,
-                    (t, answers) => new
-                    {
-                        TestId = t.TestId,
-                        StartDate = t.StartDate,
-                        WrongAnswers = t.WrongAnswers
                     })
                 .Where(a => a.StartDate >= dateFrom.DateTime && a.StartDate <= dateTo)
                 .Select(t => t.WrongAnswers.Count())

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultService.cs
@@ -44,9 +44,7 @@ namespace DevAdventCalendarCompetition.TestResultService
 
                 if (correctAnswersCount > 0)
                 {
-                    bonus = wrongAnswersCounts == null || wrongAnswersCounts.Length == 0 || wrongAnswersCounts.All(c => c == 0)
-                        ? 30
-                        : wrongAnswersCounts
+                    bonus = wrongAnswersCounts
                             .Select(p => _bonusPointsRule.CalculatePoints(p))
                             .Sum();
                 }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultService.cs
@@ -44,16 +44,22 @@ namespace DevAdventCalendarCompetition.TestResultService
 
                 if (correctAnswersCount > 0)
                 {
-                    bonus = wrongAnswersCounts == null || wrongAnswersCounts.Length == 0
+                    bonus = wrongAnswersCounts == null || wrongAnswersCounts.Length == 0 || wrongAnswersCounts.All(c => c == 0)
                         ? 30
                         : wrongAnswersCounts
                             .Select(p => _bonusPointsRule.CalculatePoints(p))
                             .Sum();
                 }
 
+                if (correctAnswersCount == 0)
+                {
+                    Console.WriteLine($"User did not answer any question.");
+                }
+
                 int overallPoints = _correctAnswersPointsRule.CalculatePoints(correctAnswersCount) + bonus;
 
-                Console.WriteLine($"\n\nResults for user: { id } - correct answers: { correctAnswersCount }, bonus: { bonus }, offset: { sumOffset }... Overall points: { overallPoints }");
+                Console.WriteLine($"\n\nResults for user: { id } - correct answers: { correctAnswersCount }, wrong answers per day: { string.Join(',', wrongAnswersCounts) } " +
+                                  $"\nbonus: { bonus }, offset: { sumOffset }... Overall points: { overallPoints }");
 
                 results.Add(new CompetitionResult { UserId = id, Points = overallPoints, AnsweringTimeOffset = sumOffset });
             }
@@ -66,8 +72,10 @@ namespace DevAdventCalendarCompetition.TestResultService
             // Invoke CalculateResults with correct boundary dates according to weekNumber.
 
             // Save results to DB as weekly results.
-            DateTimeOffset dateFrom = new DateTimeOffset(DateTime.Today.Year, 12, 1 + 7 * (weekNumber - 1), 20, 0, 0, TimeSpan.Zero);
-            DateTime dateTo = dateFrom.DateTime.AddDays(7);
+            DateTime dateFrom = new DateTimeOffset(DateTime.Today.Year, 12, 1 + 7 * (weekNumber - 1), 20, 0, 0, TimeSpan.Zero).DateTime;
+            DateTime dateTo = dateFrom.AddDays(7);
+
+            Console.WriteLine($"\nCurrent week number: { weekNumber }, dates from: { dateFrom.ToString(CultureInfo.InvariantCulture) }, to: { dateTo.ToString(CultureInfo.InvariantCulture) }");
 
             var userResults = CalculateResults(dateFrom, dateTo);
 

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/HomeController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/HomeController.cs
@@ -79,9 +79,14 @@ namespace DevAdventCalendarCompetition.Controllers
                 }
             }
 
+            var userPositions = this._homeService.GetUserPositions(userId);
+
             var vm = new TestResultsVm()
             {
-                CurrentUserPosition = this._homeService.GetUserPosition(userId),
+                Week1UserPosition = userPositions[0],
+                Week2UserPosition = userPositions[1],
+                Week3UserPosition = userPositions[2],
+                FinalUserPosition = userPositions[3],
                 TotalTestResults = paginatedResults
             };
 

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Home/Results.cshtml
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Home/Results.cshtml
@@ -37,14 +37,35 @@ else
         <div class="container">
             <div class="col-md-12">
                 <div class="party_text">
-                    @if (Model.CurrentUserPosition != 0)
+                    @if (Model.Week1UserPosition != 0)
                     {
                         <h1 class="mb-30">
-                            Zajmujesz <span>@Model.CurrentUserPosition</span> miejsce!
+                            1. Tydzień - <span>@Model.Week1UserPosition</span> miejsce!
                         </h1>
+
+                        @if (Model.Week2UserPosition != 0)
+                         {
+                             <h1 class="mb-30">
+                                 2. Tydzień - <span>@Model.Week2UserPosition</span> miejsce!
+                             </h1>
+
+                             @if (Model.Week3UserPosition != 0)
+                              {
+                                  <h1 class="mb-30">
+                                      3. Tydzień - <span>@Model.Week3UserPosition</span> miejsce!
+                                  </h1>
+
+                                  @if (Model.FinalUserPosition != 0)
+                                   {
+                                       <h1 class="mb-30">
+                                           Wynik całego konkursu - <span>@Model.FinalUserPosition</span> miejsce!
+                                       </h1>
+                                   }
+                              }
+                         }
                         <p>
-                            Punkty są zliczane raz w tygodniu. Twoja pozycja odnosi się do ostatniego zamkniętego tygodnia
-                            lub do całości konkursu, jeśli ten został już zakończony.
+                            Punkty są zliczane raz w tygodniu. Zajęte przez Ciebie miejsce określane jest za każdy ostatnio zamknięty tydzień
+                            lub za całość konkursu, jeśli ten został już zakończony.
                         </p>
                     }
                     else

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Vms/TestResultsVm.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Vms/TestResultsVm.cs
@@ -4,7 +4,13 @@ namespace DevAdventCalendarCompetition.Vms
 {
     public class TestResultsVm
     {
-        public int CurrentUserPosition { get; set; }
+        public int Week1UserPosition { get; set; }
+
+        public int Week2UserPosition { get; set; }
+
+        public int Week3UserPosition { get; set; }
+
+        public int FinalUserPosition { get; set; }
 
 #pragma warning disable CA2227 // Collection properties should be read only
         public Dictionary<int, PaginatedCollection<TestResultEntryVm>> TotalTestResults { get; set; }


### PR DESCRIPTION
On the results page user can see his position per every week not the last week as previous.

## Where should the reviewer start?
Fill database with results for at least first and second week of competition.

## How has this been tested?
Run app, sign in and go to results page.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
