### PR TITLE
disabled CA2007

### DIFF
--- a/src/DevAdventCalendarCompetition/Analysers.ruleset
+++ b/src/DevAdventCalendarCompetition/Analysers.ruleset
@@ -351,4 +351,7 @@
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA2007" Action="None" />
+  </Rules>
 </RuleSet>


### PR DESCRIPTION
You don't need that rule. All your projects runs in .net core, there is no synchronization context problem. Also, You don't share/publish any libraries, so no one consumes your dlls. In your case writing `ConfigureAwait(false)` is redundant,