### PR TITLE
Created distinction between New Account and Change Email

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/AccountService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/AccountService.cs
@@ -58,11 +58,6 @@ namespace DevAdventCalendarCompetition.Services
             return await this._userManager.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
         }
 
-        public async Task SendEmailConfirmationAsync(string email, string callbackUrl, bool isNewEmail)
-        {
-            await this._emailSender.SendEmailConfirmationAsync(email, callbackUrl, isNewEmail).ConfigureAwait(false);
-        }
-
         public async Task SendEmailAsync(string email, string subject, string message)
         {
             await this._emailSender.SendEmailAsync(email, subject, message).ConfigureAwait(false);
@@ -140,7 +135,7 @@ namespace DevAdventCalendarCompetition.Services
             return await this._userManager.ResetPasswordAsync(user, code, password).ConfigureAwait(false);
         }
 
-        public async Task SendEmailConfirmationAsync(string email, Uri callbackUrl, bool isNewEmail)
+        public async Task SendEmailConfirmationAsync(string email, Uri callbackUrl, bool isNewEmail = false)
         {
             if (callbackUrl is null)
             {

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/AccountService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/AccountService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using DevAdventCalendarCompetition.Repository.Models;
@@ -58,9 +58,9 @@ namespace DevAdventCalendarCompetition.Services
             return await this._userManager.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
         }
 
-        public async Task SendEmailConfirmationAsync(string email, string callbackUrl)
+        public async Task SendEmailConfirmationAsync(string email, string callbackUrl, bool isNewEmail)
         {
-            await this._emailSender.SendEmailConfirmationAsync(email, callbackUrl).ConfigureAwait(false);
+            await this._emailSender.SendEmailConfirmationAsync(email, callbackUrl, isNewEmail).ConfigureAwait(false);
         }
 
         public async Task SendEmailAsync(string email, string subject, string message)
@@ -140,14 +140,14 @@ namespace DevAdventCalendarCompetition.Services
             return await this._userManager.ResetPasswordAsync(user, code, password).ConfigureAwait(false);
         }
 
-        public async Task SendEmailConfirmationAsync(string email, Uri callbackUrl)
+        public async Task SendEmailConfirmationAsync(string email, Uri callbackUrl, bool isNewEmail)
         {
             if (callbackUrl is null)
             {
                 throw new ArgumentNullException(nameof(callbackUrl));
             }
 
-            await this._emailSender.SendEmailConfirmationAsync(email, callbackUrl.ToString()).ConfigureAwait(false);
+            await this._emailSender.SendEmailConfirmationAsync(email, callbackUrl.ToString(), isNewEmail).ConfigureAwait(false);
         }
 
         public AuthenticationProperties ConfigureExternalAuthenticationProperties(string provider, Uri redirectUrl)

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Extensions/EmailSenderExtensions.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Extensions/EmailSenderExtensions.cs
@@ -5,14 +5,29 @@ namespace DevAdventCalendarCompetition.Services.Extensions
 {
     public static class EmailSenderExtensions
     {
-        public static async Task SendEmailConfirmationAsync(this IEmailSender emailSender, string email, string link)
+        public static async Task SendEmailConfirmationAsync(this IEmailSender emailSender, string email, string link, bool isNewEmail)
         {
             if (emailSender is null)
             {
                 throw new System.ArgumentNullException(nameof(emailSender));
             }
 
-            await emailSender
+            if (isNewEmail == true)
+            {
+                await emailSender
+                .SendEmailAsync(email, "Potwierdzenie zmiany email", string.Concat(
+                    $"{$"Prosimy o potwierdzenie zmiany email poprzez kliknięcie na link <p><a href='{link}'>LINK</a></p>"}",
+                    $"{$"<p>Jeżeli autentykacja została przeprowadzona za pomocą zewnętrznego dostawcy (Facebook, Twitter, Google, GitHub), "}",
+                    $"{$"po przejściu na ekran logowania należy kliknąć w przycisk odpowiadający danemu dostawcy.</p>"}",
+                    $"{$"<p>W zakładce \"Moje konto\" możesz włączyć opcję \"Chcę otrzymywać notyfikacje email\" w celu otrzymania wiadomości email przypominającej o otwarciu okienka.</p>"}",
+                    $"{$"<p>Pozdrawiamy,<br />Elfy DevAdventCalendar</p>"}",
+                    $"{$"<p>PS. Dodatkowo będzie nam bardzo miło, jeśli dasz łapkę w górę na <a href='https://www.facebook.com/devadventcalendar/'>Facebooku</a> "}",
+                    $"{$"i <a href='https://twitter.com/dev_advent_cal'>Twitterze</a>!</p>"}"))
+                .ConfigureAwait(false);
+            }
+            else
+            {
+                await emailSender
                 .SendEmailAsync(email, "Potwierdzenie założenia konta", string.Concat(
                     $"{$"Prosimy o potwierdzenie założenia konta poprzez kliknięcie na link <p><a href='{link}'>LINK</a></p>"}",
                     $"{$"<p>Jeżeli autentykacja została przeprowadzona za pomocą zewnętrznego dostawcy (Facebook, Twitter, Google, GitHub), "}",
@@ -22,6 +37,7 @@ namespace DevAdventCalendarCompetition.Services.Extensions
                     $"{$"<p>PS. Dodatkowo będzie nam bardzo miło, jeśli dasz łapkę w górę na <a href='https://www.facebook.com/devadventcalendar/'>Facebooku</a> "}",
                     $"{$"i <a href='https://twitter.com/dev_advent_cal'>Twitterze</a>!</p>"}"))
                 .ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Interfaces/IAccountService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Interfaces/IAccountService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using DevAdventCalendarCompetition.Repository.Models;
@@ -23,7 +24,7 @@ namespace DevAdventCalendarCompetition.Services.Interfaces
 
         Task<string> GenerateEmailConfirmationTokenAsync(ClaimsPrincipal principal);
 
-        Task SendEmailConfirmationAsync(string email, Uri callbackUrl);
+        Task SendEmailConfirmationAsync(string email, Uri callbackUrl, bool isNewEmail);
 
         Task SendEmailAsync(string email, string subject, string message);
 
@@ -51,6 +52,6 @@ namespace DevAdventCalendarCompetition.Services.Interfaces
 
         Task<IdentityResult> ResetPasswordAsync(ApplicationUser user, string code, string password);
 
-        Task SendEmailConfirmationAsync(string email, string callbackUrl);
+        Task SendEmailConfirmationAsync(string email, string callbackUrl, bool isNewEmail);
     }
 }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Interfaces/IAccountService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Interfaces/IAccountService.cs
@@ -24,7 +24,7 @@ namespace DevAdventCalendarCompetition.Services.Interfaces
 
         Task<string> GenerateEmailConfirmationTokenAsync(ClaimsPrincipal principal);
 
-        Task SendEmailConfirmationAsync(string email, Uri callbackUrl, bool isNewEmail);
+        Task SendEmailConfirmationAsync(string email, Uri callbackUrl, bool isNewEmail = false);
 
         Task SendEmailAsync(string email, string subject, string message);
 
@@ -51,7 +51,5 @@ namespace DevAdventCalendarCompetition.Services.Interfaces
         Task<string> GeneratePasswordResetTokenAsync(ApplicationUser user);
 
         Task<IdentityResult> ResetPasswordAsync(ApplicationUser user, string code, string password);
-
-        Task SendEmailConfirmationAsync(string email, string callbackUrl, bool isNewEmail);
     }
 }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
@@ -137,8 +137,7 @@ namespace DevAdventCalendarCompetition.Controllers
 
                     var code = await this._accountService.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
                     var callbackUrl = this.Url.EmailConfirmationLink(user.Id, code, this.Request.Scheme);
-                    var isNewEmail = false;
-                    await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl), isNewEmail).ConfigureAwait(false);
+                    await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl)).ConfigureAwait(false);
                     return this.View("RegisterConfirmation");
                 }
 

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
@@ -137,7 +137,8 @@ namespace DevAdventCalendarCompetition.Controllers
 
                     var code = await this._accountService.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
                     var callbackUrl = this.Url.EmailConfirmationLink(user.Id, code, this.Request.Scheme);
-                    await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl)).ConfigureAwait(false);
+                    var isNewEmail = false;
+                    await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl), isNewEmail).ConfigureAwait(false);
                     return this.View("RegisterConfirmation");
                 }
 
@@ -244,7 +245,8 @@ namespace DevAdventCalendarCompetition.Controllers
 
                         var code = await this._accountService.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
                         var callbackUrl = this.Url.EmailConfirmationLink(user.Id, code, this.Request.Scheme);
-                        await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl)).ConfigureAwait(false);
+                        var isNewEmail = false;
+                        await this._accountService.SendEmailConfirmationAsync(model.Email, new Uri(callbackUrl), isNewEmail).ConfigureAwait(false);
 
                         return this.View("RegisterConfirmation");
                     }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/ManageController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/ManageController.cs
@@ -156,7 +156,8 @@ namespace DevAdventCalendarCompetition.Controllers
             var code = await this._accountService.GenerateEmailConfirmationTokenAsync(this.User).ConfigureAwait(false);
             var callbackUrl = this.Url.EmailConfirmationLink(user.Id, code, this.Request.Scheme);
             var email = user.Email;
-            await this._accountService.SendEmailConfirmationAsync(email, new Uri(callbackUrl)).ConfigureAwait(false);
+            var isNewEmail = true;
+            await this._accountService.SendEmailConfirmationAsync(email, new Uri(callbackUrl), isNewEmail).ConfigureAwait(false);
 
             this.StatusMessage = "E-mail weryfikacyjny został wysłany. Sprawdź swoją skrzynkę odbiorczą";
             return this.RedirectToAction(nameof(this.Index));

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Resources/ViewsMessages.Designer.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Resources/ViewsMessages.Designer.cs
@@ -1600,7 +1600,7 @@ namespace DevAdventCalendarCompetition.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Gramy do&lt;br&gt;24 grudnia..
+        ///   Looks up a localized string similar to Gramy do&lt;br&gt;24 grudnia.
         /// </summary>
         public static string WePlayUntilDecember {
             get {

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Resources/ViewsMessages.resx
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Resources/ViewsMessages.resx
@@ -631,7 +631,7 @@
     <value>Zapraszamy do tegorocznej edycji ;)</value>
   </data>
   <data name="WePlayUntilDecember" xml:space="preserve">
-    <value>Gramy do&lt;br&gt;24 grudnia.</value>
+    <value>Gramy do&lt;br&gt;24 grudnia</value>
   </data>
   <data name="WeRemovedWhiteSpaces" xml:space="preserve">
     <value>Nie martw się, dla uproszczenia usuniemy spacje z odpowiedzi</value>


### PR DESCRIPTION
## Description
This pull request resolve issue with email confirmation. User should receive different emials regardles of:
1) New Account registration
2) Change email address on actvie account.

## Where should the reviewer start?
My changes are with:
1. AccountController
2. MangeConroller
3. AccountService and Ineterface
5. EmialSenderExtensions

## Motivation and context
#244 
#245 

## How has this been tested?
Tests done manually:
1) When user create new account gets confirmation email:
![obraz](https://user-images.githubusercontent.com/27915290/87298822-24be8800-c50b-11ea-8ba6-ef970763c985.png)

2) When Change emial in Profile (Twoje Konto -> Profil -> put here new Email) -> Zapisz
![obraz](https://user-images.githubusercontent.com/27915290/87299401-3b191380-c50c-11ea-92f1-9beb4237aa6b.png)


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
