### PR TITLE
added GetCurrentTests for HomeService

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/TestHelper.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/TestHelper.cs
@@ -47,6 +47,38 @@ namespace DevAdventCalendarCompetition.Tests
             }
         };
 
+        public static List<TestDto> GetTestListDto() => new List<TestDto>()
+        {
+            new TestDto()
+            {
+                Id = 1,
+                Number = 1,
+                StartDate = DateTime.Today.AddDays(-1).AddHours(12),
+                EndDate = DateTime.Today.AddDays(-1).AddHours(23).AddMinutes(59),
+            },
+            new TestDto()
+            {
+                Id = 2,
+                Number = 2,
+                StartDate = DateTime.Today.AddHours(12),
+                EndDate = DateTime.Today.AddHours(23).AddMinutes(59),
+            },
+            new TestDto()
+            {
+                Id = 3,
+                Number = 3,
+                StartDate = DateTime.Today.AddDays(1).AddHours(12),
+                EndDate = DateTime.Today.AddDays(1).AddHours(23).AddMinutes(59),
+            },
+            new TestDto()
+            {
+                Id = 4,
+                Number = 4,
+                StartDate = DateTime.Today.AddDays(2).AddHours(12),
+                EndDate = DateTime.Today.AddDays(2).AddHours(23).AddMinutes(59),
+            }
+        };
+
         public static TestDto GetTestDto() => new TestDto()
         {
             Id = 1,

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/HomeServiceTest.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/HomeServiceTest.cs
@@ -62,8 +62,8 @@ namespace DevAdventCalendarCompetition.Tests.UnitTests
             var testListDto = GetTestListDto();
             var mapperMock = new Mock<IMapper>();
             mapperMock.Setup(x => x.Map<List<TestDto>>(testList)).Returns(testListDto);
-            var testAnswerRepositoryMock = new Mock<IUserTestAnswersRepository>();
-            var homeService = new HomeService(this._testAnswerRepositoryMock.Object, this._testRepositoryMock.Object, mapperMock.Object);
+            var homeService = new HomeService(this._testAnswerRepositoryMock.Object, this._testRepositoryMock.Object,
+                                              mapperMock.Object);
             this._testRepositoryMock.Setup(x => x.GetAllTests()).Returns(testList);
 
             // Act

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/HomeServiceTest.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/HomeServiceTest.cs
@@ -39,6 +39,22 @@ namespace DevAdventCalendarCompetition.Tests.UnitTests
         }
 
         [Fact]
+        public void GetCurrentTests()
+        {
+            // Arrange
+            var testAnswer = GetTestList();
+            this._testRepositoryMock.Setup(mock => mock.GetAllTests()).Returns(testAnswer);
+            this._mapper = new MapperConfiguration(cfg => cfg.AddProfile<TestProfile>()).CreateMapper();
+            var homeService = new HomeService(this._testAnswerRepositoryMock.Object, this._testRepositoryMock.Object, this._mapper);
+
+            // Act
+            var result = homeService.GetCurrentTests();
+
+            // Assert
+            Assert.IsType<List<TestDto>>(result);
+        }
+
+        [Fact]
         public void GetTestsWithUserAnswers_ReturnTestWithAnswerListDto()
         {
             // Arrange

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/HomeServiceTest.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/HomeServiceTest.cs
@@ -55,6 +55,26 @@ namespace DevAdventCalendarCompetition.Tests.UnitTests
         }
 
         [Fact]
+        public void GetCurrentTests2()
+        {
+            // Arrange
+            var testList = GetTestList();
+            var testListDto = GetTestListDto();
+            var mapperMock = new Mock<IMapper>();
+            mapperMock.Setup(x => x.Map<List<TestDto>>(testList)).Returns(testListDto);
+            var testAnswerRepositoryMock = new Mock<IUserTestAnswersRepository>();
+            var homeService = new HomeService(this._testAnswerRepositoryMock.Object, this._testRepositoryMock.Object, mapperMock.Object);
+            this._testRepositoryMock.Setup(x => x.GetAllTests()).Returns(testList);
+
+            // Act
+            var result = homeService.GetCurrentTests();
+
+            // Assert
+            Assert.IsType<List<TestDto>>(result);
+            this._testRepositoryMock.Verify(mock => mock.GetAllTests(), Times.Once());
+        }
+
+        [Fact]
         public void GetTestsWithUserAnswers_ReturnTestWithAnswerListDto()
         {
             // Arrange


### PR DESCRIPTION
## Description
Pytanie odnośnie testu. Ponieważ ten PR jest tylko na potrzeby review i będzie wkrótce usunięty użyje języka polskiego.

Dodałem jeden test sprawdzający metodę GetCurrentTests() z serwisu HomeService. Test nazywa się GetCurrentTests() i działa poprawnie. Jednak gdy usuwam jeden setup Moca do repozytorium
![obraz](https://user-images.githubusercontent.com/27915290/88919373-42118700-d26b-11ea-95b6-c4b38d3a4c82.png)
Test dalej działa poprawnie.

Moje Pytanie: Czemu jeśli analogicznie usuwam Moca do repozytorium w teście już wcześniej napisanym GetTestAnswerByUserId_ReturnTestAnswerDto()
![obraz](https://user-images.githubusercontent.com/27915290/88919579-a2082d80-d26b-11ea-9dc9-ee2f4aa6cad4.png)
To ten test już nie działa? 

Patrząc na implementacje obu testowanych metod z HomeSerwisu są podobnie zbudowane.




## Where should the reviewer start?
HomeService, HomeServiceTest

## Motivation and context

## How has this been tested?
1. Po prostu trzeba usunac Mock Setup dla mojego testu i uruchomic -> bedzie ładnie działał.
2. Trzeba usunać Mock Setup dla testu GetTestAnswerByUserId_ReturnTestAnswerDto() -> bedzię się wywalał.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
