### PR TITLE
Wrong answer to the question - showing our answer in the message

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Models/TestDto.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Models/TestDto.cs
@@ -35,5 +35,7 @@ namespace DevAdventCalendarCompetition.Services.Models
         public string DiscountLogoPath { get; set; }
 
         public bool HasUserAnswered { get; set; }
+
+        public string UserAnswer { get; set; }
     }
 }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Profiles/TestProfile.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Profiles/TestProfile.cs
@@ -16,7 +16,8 @@ namespace DevAdventCalendarCompetition.Services.Profiles
                 .ForMember(dest => dest.Answer, opt => opt.MapFrom(src => src.Answer)).ReverseMap();
             this.CreateMap<Test, TestDto>()
                 .ForMember(dest => dest.Answers, opt => opt.MapFrom(src => src.HashedAnswers))
-                .ForMember(dest => dest.HasUserAnswered, opt => opt.Ignore());
+                .ForMember(dest => dest.HasUserAnswered, opt => opt.Ignore())
+                .ForMember(dest => dest.UserAnswer, opt => opt.Ignore());
             this.CreateMap<TestDto, Test>()
                 .ForMember(dest => dest.UserCorrectAnswers, opt => opt.Ignore())
                 .ForMember(dest => dest.UserWrongAnswers, opt => opt.Ignore())

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/Controllers/TestControllerTests.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/Controllers/TestControllerTests.cs
@@ -173,7 +173,7 @@ namespace DevAdventCalendarCompetition.Tests.UnitTests.Controllers
         }
 
         [Fact]
-        public void Index_WrongAnswer_ReturnsViewWithError()
+        public void Index_WrongAnswer_ReturnsViewWithErrorAndUserAnswer()
         {
             // Arrange
             var test = GetTest(TestStatus.Started);
@@ -185,7 +185,8 @@ namespace DevAdventCalendarCompetition.Tests.UnitTests.Controllers
             };
 
             // Act
-            var result = controller.Index(test.Id, "wrongAnswer");
+            var usersWrongAnswer = "wrongAnswer";
+            var result = controller.Index(test.Id, usersWrongAnswer);
 
             // Assert
             var allErrors = controller.ModelState.Values.SelectMany(v => v.Errors);
@@ -193,6 +194,7 @@ namespace DevAdventCalendarCompetition.Tests.UnitTests.Controllers
             Assert.Contains(allErrors, x => x.ErrorMessage == ExceptionsMessages.ErrorTryAgain);
             var viewResult = Assert.IsType<ViewResult>(result);
             Assert.IsType<TestDto>(viewResult.ViewData.Model);
+            Assert.Equal(usersWrongAnswer, ((TestDto)viewResult.ViewData.Model).UserAnswer, ignoreCase: true);
         }
 
         [Fact]

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/Controllers/TestControllerTests.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Tests/UnitTests/Controllers/TestControllerTests.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
-using System.Text;
 using DevAdventCalendarCompetition.Controllers;
 using DevAdventCalendarCompetition.Models.Test;
 using DevAdventCalendarCompetition.Repository.Models;
@@ -176,6 +174,7 @@ namespace DevAdventCalendarCompetition.Tests.UnitTests.Controllers
         public void Index_WrongAnswer_ReturnsViewWithErrorAndUserAnswer()
         {
             // Arrange
+            var usersWrongAnswer = "wrongAnswer";
             var test = GetTest(TestStatus.Started);
             this._testServiceMock.Setup(x => x.GetTestByNumber(test.Id)).Returns(test);
             using var controller = new TestController(this._testServiceMock.Object);
@@ -185,7 +184,6 @@ namespace DevAdventCalendarCompetition.Tests.UnitTests.Controllers
             };
 
             // Act
-            var usersWrongAnswer = "wrongAnswer";
             var result = controller.Index(test.Id, usersWrongAnswer);
 
             // Assert
@@ -193,8 +191,8 @@ namespace DevAdventCalendarCompetition.Tests.UnitTests.Controllers
             Assert.Single(allErrors);
             Assert.Contains(allErrors, x => x.ErrorMessage == ExceptionsMessages.ErrorTryAgain);
             var viewResult = Assert.IsType<ViewResult>(result);
-            Assert.IsType<TestDto>(viewResult.ViewData.Model);
-            Assert.Equal(usersWrongAnswer, ((TestDto)viewResult.ViewData.Model).UserAnswer, ignoreCase: true);
+            var answer = Assert.IsType<TestDto>(viewResult.ViewData.Model);
+            Assert.Equal(usersWrongAnswer, answer.UserAnswer, ignoreCase: true);
         }
 
         [Fact]

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/TestController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/TestController.cs
@@ -74,6 +74,7 @@ namespace DevAdventCalendarCompetition.Controllers
             }
 
             this.SaveWrongAnswer(test.Id, finalAnswer);
+            test.UserAnswer = finalAnswer;
             this.ModelState.AddModelError("Answers", @WrongTryAgain);
 
             return this.View("Index", test);

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Resources/ViewsMessages.Designer.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Resources/ViewsMessages.Designer.cs
@@ -1807,6 +1807,15 @@ namespace DevAdventCalendarCompetition.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Odpowiedziano:.
+        /// </summary>
+        public static string YouHaveAnswered {
+            get {
+                return ResourceManager.GetString("YouHaveAnswered", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Nie odpowiedziałeś jeszcze na żadną zagadkę....
         /// </summary>
         public static string YouHaventAnswered {

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Resources/ViewsMessages.resx
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Resources/ViewsMessages.resx
@@ -699,6 +699,9 @@
   <data name="YouAreLateWithAnswer" xml:space="preserve">
     <value>Niestety, spóźniłeś się z odpowiedzią na to pytanie :(</value>
   </data>
+  <data name="YouHaveAnswered" xml:space="preserve">
+    <value>Odpowiedziano:</value>
+  </data>
   <data name="YouHaventAnswered" xml:space="preserve">
     <value>Nie odpowiedziałeś jeszcze na żadną zagadkę...</value>
   </data>

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Test/Index.cshtml
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Test/Index.cshtml
@@ -68,6 +68,10 @@
                         if (!string.IsNullOrEmpty(errorMessage.ToString()))
                         {
                             <h3 class="mb-30 text-primary">@errorMessage</h3>
+                            if (!string.IsNullOrEmpty(Model.UserAnswer))
+                            {
+                                <p class="mb-30">@YouHaveAnswered @Model.UserAnswer</p>
+                            }
                         }
 
                         if (Model.HasUserAnswered)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I have extended the dto passed to view, so from now on it contains a user's answer, thus in can be shown when needed (user provides wrong answer).

## Where should the reviewer start?
I would suggest to check [Index.cshtml](https://github.com/DevAdventCalendar/DevAdventCalendar/blob/develop/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Test/Index.cshtml) and later corresponding controller.

## Motivation and context
There is a request from users to know if they did eg. a typo when providing the answer. Related issue #266

## How has this been tested?
I have added test case in unit tests and did a manual testing.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/3052429/95756911-b6729880-0ca6-11eb-9d1f-5f9b625a3c5d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
