### PR TITLE
fixed view formating for access denied

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Account/AccessDenied.cshtml
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Account/AccessDenied.cshtml
@@ -4,7 +4,24 @@
     ViewData["Title"] = @AccessDenied;
 }
 
-<header>
-    <h2 class="text-danger">@ViewData["Title"]</h2>
-    <p class="text-danger">@NoAccessToResources</p>
-</header>
+<div class="breadcrumb_area">
+    <div class="container">
+        <div class="row">
+            <div class="breadcrumb_wrapper">
+                <div class="page_title">
+                    <h3>@Error</h3>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<section class="event_txt">
+    <div class="container">
+        <div class="row">
+            <div class="col text-center">
+                <h1>@NoAccessToResources</h1>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Quick view formating for Access Denied page.

1) When you are logged in as non-admin 
2) Goto admin/index
Current formating is:

![obraz](https://user-images.githubusercontent.com/27915290/99155299-ddadf280-26b6-11eb-9361-4e550549e7f0.png)

## Where should the reviewer start?
Only one file: Views -> Account ->AccessDenied.cshtml

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate)
After changes it looks as below: 

![obraz](https://user-images.githubusercontent.com/27915290/99155253-8d369500-26b6-11eb-985a-edc841d78607.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
