### PR TITLE
Prevent changing user name to the one with more than two words 

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Models/Manage/IndexViewModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Models/Manage/IndexViewModel.cs
@@ -5,6 +5,7 @@ namespace DevAdventCalendarCompetition.Models.Manage
     public class IndexViewModel
     {
         [Display(Name = "Nazwa użytkownika")]
+        [RegularExpression("^\\w+$", ErrorMessage = "Nazwa użytkownika może składać się wyłącznie z liter i cyfr")]
         public string Username { get; set; }
 
         public bool IsEmailConfirmed { get; set; }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Manage/Index.cshtml
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Manage/Index.cshtml
@@ -24,6 +24,7 @@
             <div class="form-group text_field text_field_default">
                 <label asp-for="Username"></label>
                 <input asp-for="Username" />
+                <span asp-validation-for="Username" class="text-danger"></span>
             </div>
             <div class="form-group text_field text_field_default">
                 <label asp-for="Email"></label>


### PR DESCRIPTION
Added regex based username validation to disallow anything but the letters and digits.

## Where should the reviewer start?
Open app, sign in and go to the account management page.

## Motivation and context
closes #439 

## How has this been tested?
Manually, on the account management page try to change user name to the one that containts disallowed characters. 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
