### PR TITLE
Manage controller - redisplay views instead of exceptions

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/ManageController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/ManageController.cs
@@ -180,11 +180,6 @@ namespace DevAdventCalendarCompetition.Controllers
                 return await this.SendVerificationEmail(model).ConfigureAwait(false);
             }
 
-            if (shouldSendVerificationEmail)
-            {
-                return await this.SendVerificationEmail(model).ConfigureAwait(false);
-            }
-
             this.StatusMessage = "Profil został zaktualizowany";
             return this.RedirectToAction(nameof(this.Index));
         }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/ManageController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/ManageController.cs
@@ -96,13 +96,16 @@ namespace DevAdventCalendarCompetition.Controllers
                 throw new ArgumentNullException(nameof(model));
             }
 
+            model.IsEmailConfirmed = user.EmailConfirmed;
+
             var shouldSendVerificationEmail = false;
             if (model.Email != email)
             {
                 var setEmailResult = await this._manageService.SetEmailAsync(user, model.Email).ConfigureAwait(false);
                 if (!setEmailResult.Succeeded)
                 {
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, ExceptionsMessages.ErrorDuringEmailConfiguration, this._accountService.GetUserId(this.User)));
+                    this.AddErrors(setEmailResult, "Email");
+                    return this.View(model);
                 }
 
                 shouldSendVerificationEmail = true;
@@ -115,7 +118,8 @@ namespace DevAdventCalendarCompetition.Controllers
                 var setUserNameResult = await this._manageService.SetUserNameAsync(user, model.Username).ConfigureAwait(false);
                 if (!setUserNameResult.Succeeded)
                 {
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, ExceptionsMessages.ErrorDuringUserNameChange, this._accountService.GetUserId(this.User)));
+                    this.AddErrors(setUserNameResult, "Username");
+                    return this.View(model);
                 }
             }
 
@@ -400,6 +404,14 @@ namespace DevAdventCalendarCompetition.Controllers
             foreach (var error in result.Errors)
             {
                 this.ModelState.AddModelError("Result", error.Description);
+            }
+        }
+
+        private void AddErrors(IdentityResult result, string key)
+        {
+            foreach (var error in result.Errors)
+            {
+                this.ModelState.AddModelError(key, error.Description);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've changed the logic in manage controller to redisplay view in case of errors, instead of throwing an exception.

## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->
Run the app and try to change to the existing email/username.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Close #476 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/28907927/100604004-3790f800-3306-11eb-8ba8-31bc76491e67.png)
![image](https://user-images.githubusercontent.com/28907927/100604013-39f35200-3306-11eb-9753-b306f08b8b54.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
