### PR TITLE
Counting only points from second week

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/ResultModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/ResultModel.cs
@@ -1,4 +1,4 @@
-﻿using DevAdventCalendarCompetition.Repository.Context;
+using DevAdventCalendarCompetition.Repository.Context;
 using DevAdventCalendarCompetition.Repository.Models;
 using System;
 using System.Collections.Generic;

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
@@ -176,33 +176,11 @@ namespace DevAdventCalendarCompetition.TestAnswerResultService.TestAnswers.Model
             dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
             {
                 Id = 8,
-                UserId = UserModel.userI.Id,
-                User = UserModel.userI,
-                TestId = this._testModel.test6.Id,
-                Test = this._testModel.test6,
-                AnsweringTime = this._testModel.test6.StartDate.Value.AddHours(2),
-                AnsweringTimeOffset = new TimeSpan(2, 0, 0)
-            });
-
-            dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
-            {
-                Id = 9,
-                UserId = UserModel.userI.Id,
-                User = UserModel.userI,
-                TestId = this._testModel.test7.Id,
-                Test = this._testModel.test7,
-                AnsweringTime = this._testModel.test7.StartDate.Value.AddHours(2),
-                AnsweringTimeOffset = new TimeSpan(2, 0, 0)
-            });
-
-            dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
-            {
-                Id = 10,
-                UserId = UserModel.userI.Id,
-                User = UserModel.userI,
-                TestId = this._testModel.test8.Id,
-                Test = this._testModel.test8,
-                AnsweringTime = this._testModel.test8.StartDate.Value.AddHours(2),
+                UserId = UserModel.userA.Id,
+                User = UserModel.userA,
+                TestId = this._testModel.test2.Id,
+                Test = this._testModel.test2,
+                AnsweringTime = this._testModel.test2.StartDate.Value.AddHours(2),
                 AnsweringTimeOffset = new TimeSpan(2, 0, 0)
             });
         }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
@@ -176,11 +176,33 @@ namespace DevAdventCalendarCompetition.TestAnswerResultService.TestAnswers.Model
             dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
             {
                 Id = 8,
-                UserId = UserModel.userA.Id,
-                User = UserModel.userA,
-                TestId = this._testModel.test2.Id,
-                Test = this._testModel.test2,
-                AnsweringTime = this._testModel.test2.StartDate.Value.AddHours(2),
+                UserId = UserModel.userI.Id,
+                User = UserModel.userI,
+                TestId = this._testModel.test6.Id,
+                Test = this._testModel.test6,
+                AnsweringTime = this._testModel.test6.StartDate.Value.AddHours(2),
+                AnsweringTimeOffset = new TimeSpan(2, 0, 0)
+            });
+
+            dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
+            {
+                Id = 9,
+                UserId = UserModel.userI.Id,
+                User = UserModel.userI,
+                TestId = this._testModel.test7.Id,
+                Test = this._testModel.test7,
+                AnsweringTime = this._testModel.test7.StartDate.Value.AddHours(2),
+                AnsweringTimeOffset = new TimeSpan(2, 0, 0)
+            });
+
+            dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
+            {
+                Id = 10,
+                UserId = UserModel.userI.Id,
+                User = UserModel.userI,
+                TestId = this._testModel.test8.Id,
+                Test = this._testModel.test8,
+                AnsweringTime = this._testModel.test8.StartDate.Value.AddHours(2),
                 AnsweringTimeOffset = new TimeSpan(2, 0, 0)
             });
         }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
@@ -41,8 +41,8 @@ namespace DevAdventCalendarCompetition.TestAnswerResultService.TestAnswers.Model
                 User = UserModel.userI,
                 TestId = this._testModel.test7.Id,
                 Test = this._testModel.test7,
-                AnsweringTime = this._testModel.test7.StartDate.Value.AddDays(8).AddHours(2),
-                AnsweringTimeOffset = new TimeSpan(8, 2, 0, 0)
+                AnsweringTime = this._testModel.test7.StartDate.Value.AddDays(1).AddHours(2),
+                AnsweringTimeOffset = new TimeSpan(1, 2, 0, 0)
             });
 
             //userI - 1 correct answer (after ranking time)

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
@@ -23,6 +23,28 @@ namespace DevAdventCalendarCompetition.TestAnswerResultService.TestAnswers.Model
                 throw new ArgumentNullException(nameof(dbContext));
             }
 
+            dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
+            {
+                Id = 16,
+                UserId = UserModel.userI.Id,
+                User = UserModel.userI,
+                TestId = this._testModel.test1.Id,
+                Test = this._testModel.test1,
+                AnsweringTime = this._testModel.test1.StartDate.Value.AddDays(8).AddHours(2).AddMilliseconds(5),
+                AnsweringTimeOffset = new TimeSpan(8, 2, 0, 0, 5)
+            });
+
+            dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
+            {
+                Id = 17,
+                UserId = UserModel.userI.Id,
+                User = UserModel.userI,
+                TestId = this._testModel.test7.Id,
+                Test = this._testModel.test7,
+                AnsweringTime = this._testModel.test7.StartDate.Value.AddDays(8).AddHours(2),
+                AnsweringTimeOffset = new TimeSpan(8, 2, 0, 0)
+            });
+
             //userI - 1 correct answer (after ranking time)
             dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
             {

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestAnswerModel.cs
@@ -28,21 +28,10 @@ namespace DevAdventCalendarCompetition.TestAnswerResultService.TestAnswers.Model
                 Id = 16,
                 UserId = UserModel.userI.Id,
                 User = UserModel.userI,
-                TestId = this._testModel.test1.Id,
-                Test = this._testModel.test1,
-                AnsweringTime = this._testModel.test1.StartDate.Value.AddDays(8).AddHours(2).AddMilliseconds(5),
-                AnsweringTimeOffset = new TimeSpan(8, 2, 0, 0, 5)
-            });
-
-            dbContext.UserTestCorrectAnswers.Add(new UserTestCorrectAnswer()
-            {
-                Id = 17,
-                UserId = UserModel.userI.Id,
-                User = UserModel.userI,
-                TestId = this._testModel.test7.Id,
-                Test = this._testModel.test7,
-                AnsweringTime = this._testModel.test7.StartDate.Value.AddDays(1).AddHours(2),
-                AnsweringTimeOffset = new TimeSpan(1, 2, 0, 0)
+                TestId = this._testModel.test8.Id,
+                Test = this._testModel.test8,
+                AnsweringTime = this._testModel.test8.StartDate.Value.AddDays(1).AddHours(2).AddMilliseconds(5),
+                AnsweringTimeOffset = new TimeSpan(1, 2, 0, 0, 5)
             });
 
             //userI - 1 correct answer (after ranking time)

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestModel.cs
@@ -46,21 +46,21 @@ namespace DevAdventCalendarCompetition.TestResultService.Tests.Models
         internal readonly Test test6 = new Test()
         {
             Id = 6,
-            StartDate = new DateTime(DateTime.Today.Year, 12, 6, 13, 0, 0),
+            StartDate = new DateTime(DateTime.Today.Year, 12, 6, 20, 0, 0),
             EndDate = new DateTime(DateTime.Today.Year, 12, 24, 23, 59, 0)
         };
 
         internal readonly Test test7 = new Test()
         {
             Id = 7,
-            StartDate = new DateTime(DateTime.Today.Year, 12, 7, 13, 0, 0),
+            StartDate = new DateTime(DateTime.Today.Year, 12, 7, 20, 0, 0),
             EndDate = new DateTime(DateTime.Today.Year, 12, 24, 23, 59, 0)
         };
 
         internal readonly Test test8 = new Test()
         {
             Id = 8,
-            StartDate = new DateTime(DateTime.Today.Year, 12, 8, 13, 0, 0),
+            StartDate = new DateTime(DateTime.Today.Year, 12, 8, 20, 0, 0),
             EndDate = new DateTime(DateTime.Today.Year, 12, 24, 23, 59, 0)
         };
         

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/Models/TestModel.cs
@@ -46,21 +46,21 @@ namespace DevAdventCalendarCompetition.TestResultService.Tests.Models
         internal readonly Test test6 = new Test()
         {
             Id = 6,
-            StartDate = new DateTime(DateTime.Today.Year, 12, 6, 20, 0, 0),
+            StartDate = new DateTime(DateTime.Today.Year, 12, 6, 13, 0, 0),
             EndDate = new DateTime(DateTime.Today.Year, 12, 24, 23, 59, 0)
         };
 
         internal readonly Test test7 = new Test()
         {
             Id = 7,
-            StartDate = new DateTime(DateTime.Today.Year, 12, 7, 20, 0, 0),
+            StartDate = new DateTime(DateTime.Today.Year, 12, 7, 13, 0, 0),
             EndDate = new DateTime(DateTime.Today.Year, 12, 24, 23, 59, 0)
         };
 
         internal readonly Test test8 = new Test()
         {
             Id = 8,
-            StartDate = new DateTime(DateTime.Today.Year, 12, 8, 20, 0, 0),
+            StartDate = new DateTime(DateTime.Today.Year, 12, 8, 13, 0, 0),
             EndDate = new DateTime(DateTime.Today.Year, 12, 24, 23, 59, 0)
         };
         

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/TestResultServiceTest.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/TestResultServiceTest.cs
@@ -213,6 +213,24 @@ namespace DevAdventCalendarCompetition.TestResultService.Tests
                 results.FirstOrDefault(x => x.UserId == UserModel.userI.Id).Week1Points.Value);
         }
 
+        [Fact]
+        public async Task UserWhoAnsweredInSecondWeekToTheFirstWeekTestShouldHaveSecondWeekPointsOnly()
+        {
+            //Arrange
+            TestResultServiceTestBase testBase = new TestResultServiceTestBase();
+            TestResultRepository testResultRepository = await testBase.GetTestResultRepositoryAsync();
+            var service = new TestResultService(testResultRepository, new CorrectAnswerPointsRule(), new BonusPointsRule(), new AnsweringTimePlaceRule(), GetTestSettings());
+
+            //Act
+            service.CalculateWeeklyResults(2);
+            var results = testResultRepository.GetFinalResults();
+
+            //Assert
+            Assert.Equal(
+                130,
+                results.FirstOrDefault(x => x.UserId == UserModel.userI.Id).Week2Points.Value);
+        }
+
         private object GetWeek1Result(Result result)
         {
             return new { UserdId = result.UserId, Week1Points = result.Week1Points, Week1Place = result.Week1Points != 0 ? result.Week1Place : int.MaxValue };

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/TestResultServiceTest.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService.Tests/TestResultServiceTest.cs
@@ -231,6 +231,24 @@ namespace DevAdventCalendarCompetition.TestResultService.Tests
                 results.FirstOrDefault(x => x.UserId == UserModel.userI.Id).Week2Points.Value);
         }
 
+        [Fact]
+        public async Task UserWithTwoCorrectAnswersForOneTestInSecondWeekShouldHaveCalculatedResultsForJustFirstAnswer()
+        {
+            //Arrange
+            TestResultServiceTestBase testBase = new TestResultServiceTestBase();
+            TestResultRepository testResultRepository = await testBase.GetTestResultRepositoryAsync();
+            var service = new TestResultService(testResultRepository, new CorrectAnswerPointsRule(), new BonusPointsRule(), new AnsweringTimePlaceRule(), GetTestSettings());
+
+            //Act
+            service.CalculateWeeklyResults(2);
+            var results = testResultRepository.GetFinalResults();
+
+            //Assert
+            Assert.Equal(
+                130,
+                results.FirstOrDefault(x => x.UserId == UserModel.userI.Id).Week2Points.Value);
+        }
+
         private object GetWeek1Result(Result result)
         {
             return new { UserdId = result.UserId, Week1Points = result.Week1Points, Week1Place = result.Week1Points != 0 ? result.Week1Place : int.MaxValue };

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultRepository.cs
@@ -36,12 +36,14 @@ namespace DevAdventCalendarCompetition.TestResultService
         
         public IEnumerable<DateTime> GetCorrectAnswersDates(string userId, DateTime dateFrom, DateTime dateTo)
         {
-            return _dbContext
+            var results = _dbContext
                 .UserTestCorrectAnswers
                 .Where(a => a.UserId == userId)
                 .Where(a => a.Test.StartDate.Value >= dateFrom && a.Test.StartDate.Value < dateTo)
                 .Where(a => a.AnsweringTime > dateFrom && a.AnsweringTime <= dateTo)
                 .Select(a => a.Test.StartDate.Value.Date);
+
+            return results;
         }
 
         public List<Result> GetFinalResults()

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.TestResultService/TestResultService.cs
@@ -48,7 +48,7 @@ namespace DevAdventCalendarCompetition.TestResultService
                 var bonus = 0;
                 foreach (var correctAnswerDate in correctAnswerDates)
                 {
-                    var wrongAnswers = wrongAnswersCounts.FirstOrDefault(w => w.TestStartDate == correctAnswerDate);
+                    var wrongAnswers = wrongAnswersCounts.FirstOrDefault(w => w.TestStartDate.Date == correctAnswerDate.Date);
                     bonus += _bonusPointsRule.CalculatePoints(wrongAnswers != null ? wrongAnswers.Count : 0);
                 }
 


### PR DESCRIPTION
There should be calculated only results from second week even if user answered in a second week - to a test from first week.

## Where should the reviewer start?
Set competition dates. Run added test.

## Motivation and context
#494 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
