### PR TITLE
Displaying wrong answers instead of number of wrong answers

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/Interfaces/IStatisticsRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/Interfaces/IStatisticsRepository.cs
@@ -17,5 +17,7 @@ namespace DevAdventCalendarCompetition.Repository.Interfaces
         public int GetHighestTestNumber(int testId);
 
         public int GetTestIdFromTestNumber(int testNumber);
+
+        public List<string> GetUserTestWrongAnswerString(string userId, int testId);
     }
 }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/StatisticsRepository.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Repository/StatisticsRepository.cs
@@ -75,5 +75,16 @@ namespace DevAdventCalendarCompetition.Repository
                 .SingleOrDefault()
                 : 0;
         }
+
+        public List<string> GetUserTestWrongAnswerString(string userId, int testId)
+        {
+            return this._dbContext.Tests.Any()
+                ? this._dbContext
+                .UserTestWrongAnswers
+                .Where(a => a.TestId == testId && a.UserId == userId)
+                .Select(a => a.Answer)
+                .ToList()
+                : null;
+        }
     }
 }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Models/StatisticsDto.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/Models/StatisticsDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace DevAdventCalendarCompetition.Services.Models
 {
@@ -7,6 +8,10 @@ namespace DevAdventCalendarCompetition.Services.Models
         public int WrongAnswerCount { get; set; }
 
         public DateTime? CorrectAnswerDateTime { get; set; }
+
+#pragma warning disable CA2227 // Collection properties should be read only
+        public List<string> WrongAnswers { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         public int TestNumber { get; set; }
     }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/StatisticsService.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition.Services/StatisticsService.cs
@@ -27,10 +27,17 @@ namespace DevAdventCalendarCompetition.Services
             {
                 currentTestId = this._statisticsRepository.GetTestIdFromTestNumber(i);
 
+                List<string> wrAns = this._statisticsRepository.GetUserTestWrongAnswerString(userId, currentTestId);
+                for (int j = 0; j < wrAns.Count - 1; j++)
+                {
+                    wrAns[j] += ", ";
+                }
+
                 allCurrentStats.Add(new StatisticsDto()
                 {
                     CorrectAnswerDateTime = this._statisticsRepository.GetUserTestCorrectAnswerDate(userId, currentTestId),
                     WrongAnswerCount = this._statisticsRepository.GetUserTestWrongAnswerCount(userId, currentTestId),
+                    WrongAnswers = wrAns,
                     TestNumber = i
                 });
             }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/ManageController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/ManageController.cs
@@ -385,6 +385,7 @@ namespace DevAdventCalendarCompetition.Controllers
                 {
                     CorrectAnswerDate = (stat.CorrectAnswerDateTime == DateTime.MinValue) ? null : stat.CorrectAnswerDateTime,
                     WrongAnswerCount = stat.WrongAnswerCount,
+                    WrongAnswers = stat.WrongAnswers,
                     TestNumber = stat.TestNumber
                 });
             }

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Models/Manage/DisplayStatisticsViewModel.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Models/Manage/DisplayStatisticsViewModel.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Collections.Generic;
 
 namespace DevAdventCalendarCompetition.Models.Manage
 {
     public class DisplayStatisticsViewModel
     {
         public int WrongAnswerCount { get; set; }
+
+#pragma warning disable CA2227 // Collection properties should be read only
+        public List<string> WrongAnswers { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         public DateTime? CorrectAnswerDate { get; set; }
 

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Manage/DisplayStatistics.cshtml
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Manage/DisplayStatistics.cshtml
@@ -24,12 +24,12 @@
     <tbody>
         @foreach (var currentStat in Model)
         {
-            <tr>
-                <th scope="row" class="col-xs-1"></th>
-                <td style="text-align: center;">@currentStat.TestNumber</td>
-                <td style="text-align: center;">@currentStat.CorrectAnswerDate</td>
-                <td style="text-align: center;">@currentStat.WrongAnswerCount</td>
-            </tr>
+        <tr>
+            <th scope="row" class="col-xs-1"></th>
+            <td style="text-align: center;">@currentStat.TestNumber</td>
+            <td style="text-align: center;">@currentStat.CorrectAnswerDate</td>
+            <td style="text-align: center;">@foreach (var WrongAnswer in currentStat.WrongAnswers)@WrongAnswer
+        </tr>
         }
     </tbody>
 </table>


### PR DESCRIPTION
Changed last column in statistics tab to display list of wrong answers instead of number of wrong answers

## Description
Added list of wrong answers to related DTO and a way of getting and displaying wrong answers

## Where should the reviewer start?
I disabled warning [CA2227](https://docs.microsoft.com/pl-pl/dotnet/fundamentals/code-analysis/quality-rules/ca2227?view=vs-2019)

## Motivation and context
closes #467

## How has this been tested?
For now it is only partially tested for none, one and many answers. 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
